### PR TITLE
fix default logging handler

### DIFF
--- a/code_crypt/cli.py
+++ b/code_crypt/cli.py
@@ -86,6 +86,8 @@ def main():
         logging.basicConfig(level=logging.INFO)
     elif config.quiet:
         logging.disable(sys.maxint)
+    else:
+        logging.basicConfig()
 
     if config.version:
             print("Code Crypt - " + str(__version__))


### PR DESCRIPTION
Currently non-verbose and non-debug logs (such as validation warnings) aren't printed because there is no default logging handler configured.