### PR TITLE
explicitly decode the readme as utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name=PACKAGE,
     version=__version__,
     description=__desc__,
-    long_description=open('%s/README.md' % DIR).read(),
+    long_description=open('%s/README.md' % DIR, 'rb').read().decode('utf8'),
     author='Nextdoor Engineering',
     author_email='nehal@nextdoor.com',
     url='https://github.com/Nextdoor/code-crypt',


### PR DESCRIPTION
Trying to install the 0.1 tarball in Python 3 fails with a unicode error when opening `README.md`.  This explicitly opens `README.md` as bytes & decodes them as utf8.  I'm pretty sure that this is what Python is supposed to be doing in `open('README.md').read()`, but obviously I'm missing something.

Once this is merged, do you mind cutting another release?