### PR TITLE
Only specify requirements needed directly by code_crypt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 boto3>=1.4.0
-futures>=3.0.5
-jmespath>=0.9.0
 cryptography>=1.6
-six>=1.10.0


### PR DESCRIPTION
Installing code_crypt in Python 3 breaks due to the futures requirement.
Futures specifies that it should not be installed on python3.  Since
code_crypt doesn't directly depend on futures anyway, it ought not list
it as a dependency.  We should allow boto3 to manage its own
dependencies.